### PR TITLE
Added addCompletedDownload method call for the case when the file has already been downloaded

### DIFF
--- a/src/android/DownloadManager.java
+++ b/src/android/DownloadManager.java
@@ -26,7 +26,34 @@ public class DownloadManager extends CordovaPlugin {
             this.startDownload(message, callbackContext);
             return true;
         }
+        if (action.equals("addCompletedDownload")) {
+            String title = args.getString(0);
+            String description = args.getString(1);
+            String mimeType = args.getString(2);
+            String path = args.getString(3);
+            long length = args.getLong(4);
+            this.addCompletedDownload(title, description, mimeType, path, length, callbackContext);
+            return true;
+        }
         return false;
+    }
+    
+    private void addCompletedDownload(String title, String description, String mimeType, String path, long length, CallbackContext callbackContext) {
+        
+        if(title != null && title.length() > 0 && description != null && description.length() > 0 && mimeType != null && mimeType.length() > 0 && path != null && path.length() > 0 && length > 0) {
+            
+            android.app.DownloadManager downloadManager = (android.app.DownloadManager) cordova.getActivity().getApplicationContext().getSystemService(Context.DOWNLOAD_SERVICE);            
+                    
+            try {
+                downloadManager.addCompletedDownload(title, description, false, mimeType, path, length, true);
+            } catch (Exception e) {
+                callbackContext.error(e.getMessage());
+            }
+            
+            callbackContext.success(title);
+        } else {
+            callbackContext.error("Invalid one or more arguments.");
+        }
     }
 
     private void startDownload(String message, CallbackContext callbackContext) {

--- a/www/DownloadManager.js
+++ b/www/DownloadManager.js
@@ -3,3 +3,7 @@ var exec = require('cordova/exec');
 exports.download = function(arg0, success, error) {
     exec(success, error, "DownloadManager", "download", [arg0]);
 };
+
+exports.addCompletedDownload = function(title, description, mimeType, path, length, success, error) {
+    exec(success, error, "DownloadManager", "addCompletedDownload", [title, description, mimeType, path, length]);
+};


### PR DESCRIPTION
Hello. I added a method that calls the addCompletedDownload method on the DownloadManager object. https://developer.android.com/reference/android/app/DownloadManager.htm

I had a situation that I already downloaded the file via the web api as an arrayBuffer and processed the possible responses from the server. I needed only to save this file and call the notification via downloadManager.
To save the file to the Downloads folder, I used cordova-plugin-file. And in order to just show the notification, I found that downloadManager has a special method.