### PR TITLE
Feature/file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Cordova plugin to download file in system's default download manager
  cordova plugin add https://github.com/vasani-arpit/cordova-plugin-downloadmanager
  ```
 
- ## How to Use 
+ ## How to Use
 
  ```
  //after device is ready
@@ -21,7 +21,7 @@ var fail = function (message) {
 var success = function (data) {
         console.log("succes");
 }
-cordova.plugins.DownloadManager.download("Your URL to download", success, fail);
+cordova.plugins.DownloadManager.download("Your URL to download", "Your file name", success, fail);
  ```
 
 ## Result

--- a/src/android/DownloadManager.java
+++ b/src/android/DownloadManager.java
@@ -22,39 +22,39 @@ public class DownloadManager extends CordovaPlugin {
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         if (action.equals("download")) {
-            String message = args.getString(0);
-            this.startDownload(message, callbackContext);
+            String url = args.getString(0);
+            String fileName = args.getString(1);
+            this.startDownload(url, fileName, callbackContext);
             return true;
         }
         return false;
     }
 
-    private void startDownload(String message, CallbackContext callbackContext) {
-        if (message != null && message.length() > 0) {
-            String filename = message.substring(message.lastIndexOf("/")+1, message.length());
+    private void startDownload(String url, String fileName, CallbackContext callbackContext) {
+        if (url != null && url.length() > 0) {
             try {
-                filename = URLDecoder.decode(filename,"UTF-8");
+                fileName = URLDecoder.decode(fileName,"UTF-8");
             } catch (UnsupportedEncodingException e) {
 
                 callbackContext.error("Error in converting filename");
             }
-            android.app.DownloadManager downloadManager = (android.app.DownloadManager) cordova.getActivity().getApplicationContext().getSystemService(Context.DOWNLOAD_SERVICE);            
-            Uri Download_Uri = Uri.parse(message);
+            android.app.DownloadManager downloadManager = (android.app.DownloadManager) cordova.getActivity().getApplicationContext().getSystemService(Context.DOWNLOAD_SERVICE);
+            Uri Download_Uri = Uri.parse(url);
             android.app.DownloadManager.Request request = new android.app.DownloadManager.Request(Download_Uri);
             //Restrict the types of networks over which this download may proceed.
             request.setAllowedNetworkTypes(android.app.DownloadManager.Request.NETWORK_WIFI | android.app.DownloadManager.Request.NETWORK_MOBILE);
             //Set whether this download may proceed over a roaming connection.
             request.setAllowedOverRoaming(false);
             //Set the title of this download, to be displayed in notifications (if enabled).
-            request.setTitle(filename);
+            request.setTitle(fileName);
             //Set a description of this download, to be displayed in notifications (if enabled)
             request.setDescription("DataSync File Download.");
-            //Set the local destination for the downloaded file to a path within the application's external files directory            
-            request.setDestinationInExternalFilesDir(cordova.getActivity().getApplicationContext(), Environment.DIRECTORY_DOWNLOADS, filename);
+            //Set the local destination for the downloaded file to a path within the application's external files directory
+            request.setDestinationInExternalFilesDir(cordova.getActivity().getApplicationContext(), Environment.DIRECTORY_DOWNLOADS, fileName);
             //Set visiblity after download is complete
             request.setNotificationVisibility(android.app.DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
             long downloadReference = downloadManager.enqueue(request);
-            callbackContext.success(message);
+            callbackContext.success(url);
         } else {
             callbackContext.error("Expected one non-empty string argument.");
         }

--- a/www/DownloadManager.js
+++ b/www/DownloadManager.js
@@ -1,5 +1,5 @@
 var exec = require('cordova/exec');
 
-exports.download = function(arg0, success, error) {
-    exec(success, error, "DownloadManager", "download", [arg0]);
+exports.download = function(arg0, arg1, success, error) {
+    exec(success, error, "DownloadManager", "download", [arg0, arg1]);
 };


### PR DESCRIPTION
This repo has been idle for a while, but I recently needed this for a project I was working on and felt the need to change it so you can pass a file name because we are using an API that returns files instead of urls pointing directly at files. This way you can decide to rename the file that is downloaded even if you are pointing at a specific file url.

If you deem it necessary, I can change it a bit to allow a null file name, in which case, the plugin will use the one from the url as you had previously.